### PR TITLE
Adds explicit uninstalling and re-installing of poli

### DIFF
--- a/.github/workflows/python-tox-testing-including-conda.yml
+++ b/.github/workflows/python-tox-testing-including-conda.yml
@@ -1,6 +1,6 @@
 name: Test (conda, python 3.9)
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build-linux:

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,8 @@ deps=
     -e.
 commands=
     sh -c 'if conda info --envs | grep -q poli__chem; then echo "poli__chem already exists"; else conda env create -f ./src/poli/objective_repository/rdkit_qed/environment.yml; fi'
-    sh -c "conda run -n poli__chem python -m pip install -U -e ."
+    sh -c "conda run -n poli__chem python -m pip uninstall poli"
+    sh -c "conda run -n poli__chem python -m pip install -e ."
     {[testenv]commands}
 
 [testenv:poli-protein-py39]
@@ -64,5 +65,6 @@ deps=
     -e.
 commands=
     sh -c 'if conda info --envs | grep -q poli__protein; then echo "poli__protein already exists"; else conda env create -f ./src/poli/objective_repository/foldx_stability/environment.yml; fi'
-    sh -c "conda run -n poli__protein python -m pip install -U -e ."
+    sh -c "conda run -n poli__chem python -m pip uninstall poli"
+    sh -c "conda run -n poli__chem python -m pip install -e ."
     {[testenv]commands}

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ deps=
     -e.
 commands=
     sh -c 'if conda info --envs | grep -q poli__chem; then echo "poli__chem already exists"; else conda env create -f ./src/poli/objective_repository/rdkit_qed/environment.yml; fi'
-    sh -c "conda run -n poli__chem python -m pip uninstall poli"
+    sh -c "conda run -n poli__chem python -m pip uninstall -y poli"
     sh -c "conda run -n poli__chem python -m pip install -e ."
     {[testenv]commands}
 
@@ -65,6 +65,6 @@ deps=
     -e.
 commands=
     sh -c 'if conda info --envs | grep -q poli__protein; then echo "poli__protein already exists"; else conda env create -f ./src/poli/objective_repository/foldx_stability/environment.yml; fi'
-    sh -c "conda run -n poli__chem python -m pip uninstall poli"
+    sh -c "conda run -n poli__chem python -m pip uninstall -y poli"
     sh -c "conda run -n poli__chem python -m pip install -e ."
     {[testenv]commands}


### PR DESCRIPTION
Currently, the process of testing poli involves creating `conda` environments that install the freshest version **from git**. We should instead force these installations to be the branch version.