### PR TITLE
added conda environment str not specified, abs path

### DIFF
--- a/src/poli/core/util/objective_management/make_run_script.py
+++ b/src/poli/core/util/objective_management/make_run_script.py
@@ -94,7 +94,13 @@ def _make_run_script(
 
         conda_environment_name = str(conda_environment_name)
     else:
-        raise ValueError("conda_environment_location must be a string or a Path.")
+        if conda_environment_name is None:
+            conda_environment_name = sys.executable[: -len("/bin/python")]
+            conda_environment_name = str(os.path.abspath(conda_environment_name))
+        else:
+            raise ValueError(
+                "If specified, conda_environment_location must be a string or a Path."
+            )
 
     # make path to conda environment absolute
     if python_paths is None:


### PR DESCRIPTION
previously, if the condo environment is not specified, register_problem fails.
However poli be able to work with existing environment, in case Path or name are not specified.