### PR TITLE
Adds a way to start objective functions using a context manager

### DIFF
--- a/examples/a_simple_objective_function_registration/querying_aloha.py
+++ b/examples/a_simple_objective_function_registration/querying_aloha.py
@@ -21,3 +21,9 @@ if __name__ == "__main__":
     y1 = f(x1)
     print(x1, y1)
     f.terminate()
+
+    # Another example (using the start function)
+    with objective_factory.start(name="our_aloha") as f:
+        x = np.array(["F", "L", "E", "A", "S"]).reshape(1, -1)
+        y = f(x)
+        print(x, y)

--- a/src/poli/core/abstract_black_box.py
+++ b/src/poli/core/abstract_black_box.py
@@ -73,6 +73,9 @@ class AbstractBlackBox:
     def terminate(self):
         pass
 
+    def __enter__(self):
+        return self
+
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.terminate()
 

--- a/src/poli/tests/docs_examples/test_baseline_optimization.py
+++ b/src/poli/tests/docs_examples/test_baseline_optimization.py
@@ -5,6 +5,8 @@ def test_optimizing_aloha():
     """
     If poli_baselines is available, this test checks
     whether we can optimize the aloha problem.
+    TODO: This depends on poli baselines. We should mock that behavior,
+    or move this test to the poli_baselines package.
     """
     from poli import objective_factory
     from poli.core.registry import get_problems
@@ -25,7 +27,6 @@ def test_optimizing_aloha():
         black_box=f,
         x0=x0,
         y0=y0,
-        alphabet=problem_info.get_alphabet(),
     )
 
     # Running the optimization for 1000 steps,

--- a/src/poli/tests/registry/test_problem_registration.py
+++ b/src/poli/tests/registry/test_problem_registration.py
@@ -98,6 +98,7 @@ def test_force_registering_qed_with_context_manager():
     """
     with objective_factory.start(
         name="rdkit_qed",
+        force_register=True,
         force_isolation=True,
         path_to_alphabet=THIS_DIR / "alphabet_qed.json",
     ) as f:

--- a/src/poli/tests/registry/test_problem_registration.py
+++ b/src/poli/tests/registry/test_problem_registration.py
@@ -92,6 +92,20 @@ def test_force_registering_qed():
     f.terminate()
 
 
+def test_force_registering_qed_with_context_manager():
+    """
+    Tests the objective_factory.start method on QED.
+    """
+    with objective_factory.start(
+        name="rdkit_qed",
+        force_isolation=True,
+        path_to_alphabet=THIS_DIR / "alphabet_qed.json",
+    ) as f:
+        x = np.array([["C"]])
+        y = f(x)
+        assert np.isclose(y, 0.35978494).all()
+
+
 def test_force_registering_logp():
     """
     We test whether we can force-register the logp problem
@@ -308,7 +322,3 @@ def test_registering_foldx_stability_and_sasa():
 
     assert np.isclose(y0[:, 0], 32.4896).all()
     assert np.isclose(y0[:, 1], 8411.45578009).all()
-
-
-if __name__ == "__main__":
-    test_registering_foldx_sasa()

--- a/tox.ini
+++ b/tox.ini
@@ -20,8 +20,8 @@ commands =
     sh -c "conda run -n poli__chem python -m pip uninstall -y poli"
     sh -c "conda run -n poli__chem python -m pip install -e ."
     sh -c 'if conda info --envs | grep -q poli__protein; then echo "poli__protein already exists"; else conda env create -f ./src/poli/objective_repository/foldx_stability/environment.yml; fi'
-    sh -c "conda run -n poli__chem python -m pip uninstall -y poli"
-    sh -c "conda run -n poli__chem python -m pip install -e ."
+    sh -c "conda run -n poli__protein python -m pip uninstall -y poli"
+    sh -c "conda run -n poli__protein python -m pip install -e ."
     pytest {tty:--color=yes} -v {posargs}
     sh -c "rm -rf ~/.poli_objectives"
 


### PR DESCRIPTION
Now there's a new way to instantiate objective functions that allows the user to forget about `f.terminate()`, which sometimes doesn't close gracefully (thus closing #21).

It works as follows:

```python
import numpy as np
from poli import objective_factory

with objective_factory.start(name="aloha") as f:
    x0 = np.array([list("ALOOF")])
    print(f(x0))   # Should be 3.

# At this point, the connection closes automatically.
```

This pull request includes this new way of doing it in the examples.