### PR TITLE
set default seed None

### DIFF
--- a/src/poli/objective_repository/foldx_rfp_lambo/register.py
+++ b/src/poli/objective_repository/foldx_rfp_lambo/register.py
@@ -68,13 +68,14 @@ class RFPWrapperFactory(AbstractProblemFactory):
 
     def create(
         self,
-        seed: int = 0,
+        seed: int = None,
         batch_size: int = None,
         parallelize: bool = False,
         num_workers: int = None,
     ) -> Tuple[AbstractBlackBox, np.ndarray, np.ndarray]:
         config = get_config()
         config = conf
+
         # make problem reproducible
         random.seed(seed)
         torch.manual_seed(seed)


### PR DESCRIPTION
Looks like the seed logic for Lambo problems is on the observer side after all.
For the CoRel setup everything is in order.
Writing a seed in the config, would make the problems static. We want to obtain it from the trial_id or the seed from Lambo side.