### PR TITLE
71 abstract black box batched observe fails if batch shape wrong

### DIFF
--- a/src/poli/core/abstract_black_box.py
+++ b/src/poli/core/abstract_black_box.py
@@ -73,14 +73,11 @@ class AbstractBlackBox:
         # We evaluate x in batches.
         for x_batch_ in batched(x, batch_size):
             # We reshape the batch to be 2D, even if the batch size is 1.
-            try:
-                x_batch = (
-                    np.concatenate(x_batch_, axis=0).reshape(len(x_batch_), -1)
-                    if batch_size > 1
-                    else np.array(x_batch_)
-                )
-            except ValueError:  # in case unaligned sequences or zero dimensional
-                x_batch = np.array(x_batch_)
+            x_batch = (
+                np.concatenate(x_batch_, axis=0).reshape(len(x_batch_), -1)
+                if batch_size > 1
+                else np.array(x_batch_)
+            )
 
             # We evaluate the batch in parallel if the user wants to.
             if self.parallelize:

--- a/src/poli/core/abstract_black_box.py
+++ b/src/poli/core/abstract_black_box.py
@@ -103,10 +103,13 @@ class AbstractBlackBox:
             # We pass the information to the observer, if any.
             if self.observer is not None:
                 # observer logic s.t. observations are individual - later aggregate w.r.t batch_size
-                for i in range(x_batch.shape[0]):
-                    _x = np.atleast_2d(x_batch[i])
-                    _y = np.atleast_2d(f_batch[i])
-                    self.observer.observe(_x, _y, context)
+                if x_batch.shape[0] > 1:
+                    for i in range(x_batch.shape[0]):
+                        _x = np.atleast_2d(x_batch[i])
+                        _y = np.atleast_2d(f_batch[i])
+                        self.observer.observe(_x, _y, context)
+                else:
+                    self.observer.observe(x_batch, f_batch, context)
 
             f_evals.append(f_batch)
 
@@ -118,9 +121,9 @@ class AbstractBlackBox:
         raise NotImplementedError("abstract method")
 
     def terminate(self) -> None:
-        if self.observer is not None:
-            # NOTE: terminating a problem should gracefully end the observer process -> write the last state.
-            self.observer.finish()
+        # if self.observer is not None:
+        #     # NOTE: terminating a problem should gracefully end the observer process -> write the last state.
+        #     self.observer.finish()
         return
 
     def __enter__(self):

--- a/src/poli/core/abstract_black_box.py
+++ b/src/poli/core/abstract_black_box.py
@@ -87,13 +87,7 @@ class AbstractBlackBox:
                     )
                     f_batch = np.array(f_batch_).reshape(len(x_batch_), -1)
             else:  # iterative treatment
-                if x_batch.shape[0] > 1:
-                    _f_batch = np.array(
-                        [self._black_box(_x, context) for _x in x_batch]
-                    )
-                    f_batch = np.array(_f_batch).reshape(len(x_batch_), -1)
-                else:
-                    f_batch = self._black_box(x_batch, context)
+                f_batch = self._black_box(x_batch, context)
 
             assert (
                 len(f_batch.shape) == 2

--- a/src/poli/core/abstract_black_box.py
+++ b/src/poli/core/abstract_black_box.py
@@ -97,7 +97,9 @@ class AbstractBlackBox:
                 f_batch, np.ndarray
             ), f"type(f)={type(f_batch)}, not np.ndarray"
 
-            assert x_batch.shape[0] == f_batch.shape[0], f"Inconsistent evaluation axis=0 x={x_batch.shape} != black_box y={f_batch.shape}"
+            assert (
+                x_batch.shape[0] == f_batch.shape[0]
+            ), f"Inconsistent evaluation axis=0 x={x_batch.shape} != black_box y={f_batch.shape}"
 
             # We pass the information to the observer, if any.
             if self.observer is not None:

--- a/src/poli/core/abstract_black_box.py
+++ b/src/poli/core/abstract_black_box.py
@@ -86,8 +86,14 @@ class AbstractBlackBox:
                         self._black_box, [(x.reshape(1, -1), context) for x in x_batch]
                     )
                     f_batch = np.array(f_batch_).reshape(len(x_batch_), -1)
-            else:
-                f_batch = self._black_box(x_batch, context)
+            else:  # iterative treatment
+                if x_batch.shape[0] > 1:
+                    _f_batch = np.array(
+                        [self._black_box(_x, context) for _x in x_batch]
+                    )
+                    f_batch = np.array(_f_batch).reshape(len(x_batch_), -1)
+                else:
+                    f_batch = self._black_box(x_batch, context)
 
             assert (
                 len(f_batch.shape) == 2

--- a/src/poli/core/abstract_black_box.py
+++ b/src/poli/core/abstract_black_box.py
@@ -97,6 +97,8 @@ class AbstractBlackBox:
                 f_batch, np.ndarray
             ), f"type(f)={type(f_batch)}, not np.ndarray"
 
+            assert x_batch.shape[0] == f_batch.shape[0], f"Inconsistent evaluation axis=0 x={x_batch.shape} != black_box y={f_batch.shape}"
+
             # We pass the information to the observer, if any.
             if self.observer is not None:
                 # observer logic s.t. observations are individual - later aggregate w.r.t batch_size


### PR DESCRIPTION
1. added assert to ensure batch shape between X and y consistent
2. iterative treatment of x observation if evaluation not parallelized
3. removed try - except to enforce correct reshaping