### PR TITLE
Allows for string paths & Add regression tests to the foldx interface

### DIFF
--- a/src/poli/core/util/proteins/foldx.py
+++ b/src/poli/core/util/proteins/foldx.py
@@ -3,7 +3,7 @@ This module contains utilities for querying
 foldx for repairing and simulating the mutations
 of proteins. 
 """
-from typing import List
+from typing import List, Union
 from pathlib import Path
 import shutil
 import subprocess
@@ -50,14 +50,23 @@ if not (PATH_TO_FOLDX_FILES / "rotabase.txt").exists():
 
 
 class FoldxInterface:
-    def __init__(self, working_dir: Path):
+    def __init__(self, working_dir: Union[Path, str]):
+        if isinstance(working_dir, str):
+            working_dir = Path(working_dir)
+
         self.working_dir = working_dir
 
-    def repair(self, pdb_file: Path, remove_and_rename: bool = False) -> None:
+    def repair(
+        self, pdb_file: Union[str, Path], remove_and_rename: bool = False
+    ) -> None:
         """
         This method repairs a PDB file with FoldX, overwriting
         the original file if remove_and_rename is True (default: False).
         """
+        # Make sure the pdb file is a path
+        if isinstance(pdb_file, str):
+            pdb_file = Path(pdb_file)
+
         # Make sure the relevant files are in the
         # working directory
         self.copy_foldx_files(pdb_file)

--- a/src/poli/tests/util/test_foldx_interface.py
+++ b/src/poli/tests/util/test_foldx_interface.py
@@ -1,0 +1,71 @@
+"""
+This module tests the foldx interface, which can be found in
+poli.core.util.proteins.foldx
+
+Since this code is only intended to run inside the
+poli__protein environment, we add a skip to the
+whole module if the import fails.
+"""
+import pytest
+
+from pathlib import Path
+
+try:
+    from poli.core.util.proteins.foldx import (
+        FoldxInterface,
+    )
+except (ImportError, FileNotFoundError):
+    pytest.skip("Could not import the foldx interface. ", allow_module_level=True)
+
+try:
+    from poli.core.util.proteins.pdb_parsing import (
+        parse_pdb_as_residue_strings,
+    )
+except ImportError:
+    pytest.skip(
+        "Could not import the protein utilities for parsing. ", allow_module_level=True
+    )
+
+THIS_DIR = Path(__file__).parent.resolve()
+
+
+class TestFoldxInterface:
+    wildtype_pdb_path = THIS_DIR / "3ned.pdb"
+    tmp_path = THIS_DIR / "tmp"
+
+    foldx_interface = FoldxInterface(tmp_path)
+
+    def test_copying_files(self):
+        """
+        Tests that the files are copied correctly.
+        """
+        self.tmp_path.mkdir(exist_ok=True)
+
+        self.foldx_interface.copy_foldx_files(self.wildtype_pdb_path)
+
+        assert (self.foldx_interface.working_dir / "rotabase.txt").exists()
+        assert (
+            self.foldx_interface.working_dir / f"{self.wildtype_pdb_path.stem}.pdb"
+        ).exists()
+
+        # Clean up
+        (self.foldx_interface.working_dir / "rotabase.txt").unlink()
+        (
+            self.foldx_interface.working_dir / f"{self.wildtype_pdb_path.stem}.pdb"
+        ).unlink()
+
+    def test_specifying_string_working_dir(self):
+        new_foldx_interface = FoldxInterface(str(self.tmp_path))
+
+        new_foldx_interface.copy_foldx_files(self.wildtype_pdb_path)
+
+        assert (new_foldx_interface.working_dir / "rotabase.txt").exists()
+        assert (
+            new_foldx_interface.working_dir / f"{self.wildtype_pdb_path.stem}.pdb"
+        ).exists()
+
+        # Clean up
+        (new_foldx_interface.working_dir / "rotabase.txt").unlink()
+        (
+            new_foldx_interface.working_dir / f"{self.wildtype_pdb_path.stem}.pdb"
+        ).unlink()


### PR DESCRIPTION
(Closes #40) We allow the user to provide `str`s instead of `Pathlib.Path`s as working directories and pdb filepaths. We'll convert them to `Path`s if they are strings, essentially. We also add a regression test for this bug.