### PR TITLE
Embedding toy continuous problems in higher dimensions

### DIFF
--- a/src/poli/objective.py
+++ b/src/poli/objective.py
@@ -80,6 +80,8 @@ def run(factory_kwargs: str, objective_name: str, port: int, password: str) -> N
 
     # make connection with the mother process
     conn = get_connection(port, password)
+
+    # TODO: We could be receiving the kwargs for the factory here.
     msg_type, seed = conn.recv()
 
     # dynamically load objective function module

--- a/src/poli/objective_repository/toy_continuous_problem/register.py
+++ b/src/poli/objective_repository/toy_continuous_problem/register.py
@@ -39,6 +39,7 @@ class ToyContinuousBlackBox(AbstractBlackBox):
         num_workers: int = None,
         function_name: str = None,
         n_dimensions: int = 2,
+        embed_in: int = None,
     ):
         self.alphabet = None
 
@@ -47,7 +48,13 @@ class ToyContinuousBlackBox(AbstractBlackBox):
         ), f"'{function_name}' is not a valid function name. Expected it to be one of {POSSIBLE_FUNCTIONS}."
 
         self.function_name = function_name
-        self.function = ToyContinuousProblem(function_name, n_dims=n_dimensions)
+        self.n_dimensions = n_dimensions
+        self.embed_in = embed_in
+        self.function = ToyContinuousProblem(
+            function_name,
+            n_dims=n_dimensions,
+            embed_in=embed_in,
+        )
 
         super().__init__(
             info=info,
@@ -86,6 +93,7 @@ class ToyContinuousProblemFactory(AbstractProblemFactory):
         num_workers: int = None,
         function_name: str = None,
         n_dimensions: int = 2,
+        embed_in: int = None,
     ) -> Tuple[AbstractBlackBox, np.ndarray, np.ndarray]:
         assert (
             function_name in POSSIBLE_FUNCTIONS
@@ -103,8 +111,12 @@ class ToyContinuousProblemFactory(AbstractProblemFactory):
             num_workers=num_workers,
             function_name=function_name,
             n_dimensions=n_dimensions,
+            embed_in=embed_in,
         )
-        x0 = np.array([[0.0] * n_dimensions])
+        if embed_in is None:
+            x0 = np.array([[0.0] * n_dimensions])
+        else:
+            x0 = np.array([[0.0] * embed_in])
 
         return f, x0, f(x0)
 

--- a/src/poli/tests/registry/toy_continuous_problems/test_embedding_problems_into_higher_dims.py
+++ b/src/poli/tests/registry/toy_continuous_problems/test_embedding_problems_into_higher_dims.py
@@ -1,0 +1,53 @@
+"""Tests embedding continuous toy objectives into higher dimensions.
+
+For some objective functions that are defined in 2D
+space, we give the users the affordance to embed them
+in higher dimensions. This is useful for testing
+higher dimensional Bayesian Optimization algorithms,
+since some of them assume that the intrinsic dimensionality
+of the problem is lower than the actual dimensionality.
+"""
+import numpy as np
+
+
+def test_embed_camelback_into_high_dimensions():
+    from poli import objective_factory
+    from poli.objective_repository.toy_continuous_problem.register import (
+        ToyContinuousProblem,
+    )
+
+    _, f_camelback, _, _, _ = objective_factory.create(
+        name="toy_continuous_problem",
+        function_name="camelback_2d",
+        n_dimensions=2,
+        embed_in=10,
+    )
+    f_camelback: ToyContinuousProblem
+
+    dimensions_to_embed_in = f_camelback.function.dimensions_to_embed_in
+
+    # Testing whether the output is the same as long as we
+    # are in the same subspace.
+    one_x = np.random.randn(10).reshape(1, -1)
+    another_x = np.random.randn(10).reshape(1, -1)
+
+    one_x[0, dimensions_to_embed_in] = [0.0, 0.0]
+    another_x[0, dimensions_to_embed_in] = [0.0, 0.0]
+
+    assert np.allclose(
+        f_camelback(one_x),
+        f_camelback(another_x),
+    )
+
+    # Testing whether the output is different if we are
+    # in different subspaces.
+    one_x[0, dimensions_to_embed_in] = [1.0, 1.0]
+
+    assert not np.allclose(
+        f_camelback(one_x),
+        f_camelback(another_x),
+    )
+
+
+if __name__ == "__main__":
+    test_embed_camelback_into_high_dimensions()


### PR DESCRIPTION
Since some optimization algorithms focus on exploting low-dimensional intrinsic dimensionality, this PR implements a way to embed a given continuous toy objective function into higher dimensions. When creating an objective function, the user can pass a `embed_in: int = None` kwarg, and the objective function will be embedded into randomly selected coordinates.