### PR TITLE
Installs poli from the dev branch instead of master

### DIFF
--- a/examples/the_basics/a_simple_objective_function_registration/environment.yml
+++ b/examples/the_basics/a_simple_objective_function_registration/environment.yml
@@ -6,4 +6,4 @@ dependencies:
   - pip
   - pip:
     - numpy
-    - "git+https://github.com/MachineLearningLifeScience/poli.git@master"
+    - "git+https://github.com/MachineLearningLifeScience/poli.git@dev"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,10 @@ build-backend = "setuptools.build_meta"
 name = "poli"
 version = "0.0.1"
 dependencies = [
-    "numpy"
+    "numpy",
+    "rdkit",
+    "selfies",
+    "dockstring"
 ]
 
 [tool.pytest.ini_options]

--- a/src/poli/objective_repository/foldx_sasa/environment.yml
+++ b/src/poli/objective_repository/foldx_sasa/environment.yml
@@ -10,4 +10,4 @@ dependencies:
     - python-levenshtein
     - numpy
     - pdb-tools
-    - "git+https://github.com/MachineLearningLifeScience/poli.git@master"
+    - "git+https://github.com/MachineLearningLifeScience/poli.git@dev"

--- a/src/poli/objective_repository/foldx_stability/environment.yml
+++ b/src/poli/objective_repository/foldx_stability/environment.yml
@@ -10,4 +10,4 @@ dependencies:
     - python-levenshtein
     - numpy
     - pdb-tools
-    - "git+https://github.com/MachineLearningLifeScience/poli.git@master"
+    - "git+https://github.com/MachineLearningLifeScience/poli.git@dev"

--- a/src/poli/objective_repository/foldx_stability_and_sasa/environment.yml
+++ b/src/poli/objective_repository/foldx_stability_and_sasa/environment.yml
@@ -10,4 +10,4 @@ dependencies:
     - python-levenshtein
     - numpy
     - pdb-tools
-    - "git+https://github.com/MachineLearningLifeScience/poli.git@master"
+    - "git+https://github.com/MachineLearningLifeScience/poli.git@dev"

--- a/src/poli/objective_repository/rdkit_logp/environment.yml
+++ b/src/poli/objective_repository/rdkit_logp/environment.yml
@@ -8,4 +8,4 @@ dependencies:
     - numpy
     - rdkit
     - selfies
-    - "git+https://github.com/MachineLearningLifeScience/poli.git@master"
+    - "git+https://github.com/MachineLearningLifeScience/poli.git@dev"

--- a/src/poli/objective_repository/rdkit_qed/environment.yml
+++ b/src/poli/objective_repository/rdkit_qed/environment.yml
@@ -8,4 +8,4 @@ dependencies:
     - numpy
     - rdkit
     - selfies
-    - "git+https://github.com/MachineLearningLifeScience/poli.git@master"
+    - "git+https://github.com/MachineLearningLifeScience/poli.git@dev"

--- a/src/poli/objective_repository/super_mario_bros/environment.yml
+++ b/src/poli/objective_repository/super_mario_bros/environment.yml
@@ -11,4 +11,4 @@ dependencies:
   - pip
   - pip:
     - numpy
-    - "git+https://github.com/MachineLearningLifeScience/poli.git@master"
+    - "git+https://github.com/MachineLearningLifeScience/poli.git@dev"

--- a/src/poli/objective_repository/toy_continuous_problem/environment.yml
+++ b/src/poli/objective_repository/toy_continuous_problem/environment.yml
@@ -6,4 +6,4 @@ dependencies:
   - pip
   - pip:
     - numpy
-    - "git+https://github.com/MachineLearningLifeScience/poli.git@master"
+    - "git+https://github.com/MachineLearningLifeScience/poli.git@dev"

--- a/src/poli/objective_repository/white_noise/environment.yml
+++ b/src/poli/objective_repository/white_noise/environment.yml
@@ -6,4 +6,4 @@ dependencies:
   - pip
   - pip:
     - numpy
-    - "git+https://github.com/MachineLearningLifeScience/poli.git@master"
+    - "git+https://github.com/MachineLearningLifeScience/poli.git@dev"


### PR DESCRIPTION
While we set-up the tutorials on `colab`, this temporary fix installs the environment's `poli` from the bleeding-edge version.