### PR TITLE
Foldx rfp lambo base candidate communication

### DIFF
--- a/src/poli/objective_repository/foldx_rfp_lambo/environment.yml
+++ b/src/poli/objective_repository/foldx_rfp_lambo/environment.yml
@@ -30,3 +30,4 @@ dependencies:
     - h5py
     - tqdm
     - scikit-learn
+    - "git+https://github.com/samuelstanton/lambo.git@431b052ad0e54a1ba4519272725310127c6377f1"

--- a/src/poli/objective_repository/foldx_rfp_lambo/register.py
+++ b/src/poli/objective_repository/foldx_rfp_lambo/register.py
@@ -107,10 +107,10 @@ class RFPWrapperFactory(AbstractProblemFactory):
         permutation = np.arange(all_seqs.shape[0])
         base_candidate_idx = np.array([0, 3, 4, 16, 37, 39])
         permutation[base_candidate_idx] = np.arange(base_candidate_idx.shape[0])
-        permutation[:base_candidate_idx.shape[0]] = base_candidate_idx
+        permutation[: base_candidate_idx.shape[0]] = base_candidate_idx
         all_seqs = all_seqs[permutation, ...]
         all_targets = all_targets[permutation, ...]
-        assert np.all(all_targets[:base_targets.shape[0], ...] == base_targets)
+        assert np.all(all_targets[: base_targets.shape[0], ...] == base_targets)
 
         if self.problem_sequence in all_seqs:
             # substitute erroneous sequence "X in position 159" with correct PDB fasta sequence

--- a/src/poli/objective_repository/foldx_rfp_lambo/register.py
+++ b/src/poli/objective_repository/foldx_rfp_lambo/register.py
@@ -102,6 +102,16 @@ class RFPWrapperFactory(AbstractProblemFactory):
         base_candidates, base_targets, all_seqs, all_targets = bb_task.task_setup(
             config, project_root=project_root
         )
+
+        # to ensure that algorithms will only request valid sequences, we provide the base sequences first
+        permutation = np.arange(all_seqs.shape[0])
+        base_candidate_idx = np.array([0, 3, 4, 16, 37, 39])
+        permutation[base_candidate_idx] = np.arange(base_candidate_idx.shape[0])
+        permutation[:base_candidate_idx.shape[0]] = base_candidate_idx
+        all_seqs = all_seqs[permutation, ...]
+        all_targets = all_targets[permutation, ...]
+        assert np.all(all_targets[:base_targets.shape[0], ...] == base_targets)
+
         if self.problem_sequence in all_seqs:
             # substitute erroneous sequence "X in position 159" with correct PDB fasta sequence
             all_seqs[


### PR DESCRIPTION
Changed the `registry.py` s.t. the `base_candidates` that the LamBO FOLDX wrapper uses for evaluation are always among the first sequences given. This is to ensure that algorithms applied to this problem can better propose valid sequences.