### PR TITLE
remove CBas imports from __init__

### DIFF
--- a/src/poli/objective_repository/__init__.py
+++ b/src/poli/objective_repository/__init__.py
@@ -97,16 +97,6 @@ try:
 except (ImportError, FileNotFoundError):
     pass
 
-try:
-    from .gfp_cbas.register import GFPCBasProblemFactory
-
-    AVAILABLE_PROBLEM_FACTORIES["gfp_cbas"] = GFPCBasProblemFactory
-    AVAILABLE_PROBLEM_FACTORIES["gfp_cbas_gp"] = GFPCBasProblemFactory
-    AVAILABLE_PROBLEM_FACTORIES["gfp_cbas_elbo"] = GFPCBasProblemFactory
-    AVAILABLE_PROBLEM_FACTORIES["gfp_cbas_vae"] = GFPCBasProblemFactory
-except (ImportError, FileNotFoundError):
-    pass
-
 
 try:
     from .gfp_select.register import GFPSelectionProblemFactory


### PR DESCRIPTION
Removed cbas_gfp inputs from `__init__.py` , as they create TF warnings and can create tf environment issues.