### PR TITLE
Allows flat inputs (i.e. `[b,]` instead of `[b, L]`) to black-boxes

### DIFF
--- a/src/poli/core/abstract_black_box.py
+++ b/src/poli/core/abstract_black_box.py
@@ -19,15 +19,19 @@ class AbstractBlackBox:
     Parameters
     ----------
     info : ProblemSetupInformation
-        The problem setup information object that provides details about the problem.
+        The problem setup information object that provides details about the
+        problem.
     batch_size : int, optional
         The batch size for evaluating the black box function. Default is None.
     parallelize : bool, optional
-        Flag indicating whether to evaluate the black box function in parallel. Default is False.
+        Flag indicating whether to evaluate the black box function in parallel.
+        Default is False.
     num_workers : int, optional
-        The number of workers to use for parallel evaluation. Default is None, which uses half of the available CPU cores.
+        The number of workers to use for parallel evaluation. Default is None,
+        which uses half of the available CPU cores.
     evaluation_budget : int, optional
-        The maximum number of evaluations allowed for the black box function. Default is float("inf").
+        The maximum number of evaluations allowed for the black box function.
+        Default is float("inf").
 
     Attributes
     ----------
@@ -47,7 +51,8 @@ class AbstractBlackBox:
     set_observer(observer)
         Set the observer object for recording observations during evaluation.
     reset_evaluation_budget()
-        Reset the evaluation budget by setting the number of evaluations made to 0.
+        Reset the evaluation budget by setting the number of evaluations made
+        to 0.
     __call__(x, context=None)
         Evaluate the black box function for the given input.
     _black_box(x, context=None)
@@ -61,7 +66,8 @@ class AbstractBlackBox:
     __del__()
         Destructor for the black box optimization problem.
     __neg__()
-        Create a new black box with the objective function as the negative of the original one.
+        Create a new black box with the objective function as the negative
+        of the original one.
     """
 
     def __init__(
@@ -119,10 +125,11 @@ class AbstractBlackBox:
     def __call__(self, x: np.array, context=None):
         """Calls the black box function.
 
-        The purpose of this function is to enforce that inputs are equal across problems.
-        The inputs are usually assumed to be strings, and all objective functions in our
-        repository will assume that the inputs are strings. Some also allow for integers
-        (i.e. token ids) to be passed as inputs. Some problems have continuous inputs, too.
+        The purpose of this function is to enforce that inputs are equal across
+        problems. The inputs are usually assumed to be strings, and all
+        objective functions in our repository will assume that the inputs are
+        strings. Some also allow for integers (i.e. token ids) to be passed as
+        inputs. Some problems have continuous inputs, too.
 
         Parameters
         ----------
@@ -139,7 +146,7 @@ class AbstractBlackBox:
         Raises
         ------
         AssertionError
-            If the input is not a 2D array.
+            If the input is not a 2D array (when the sequences were supposed to be aligned).
         AssertionError
             If the length of the input does not match the maximum sequence length of the problem.
         AssertionError
@@ -153,7 +160,29 @@ class AbstractBlackBox:
         # the problem. One can opt out of this by setting L=np.inf
         # or L=None.
         if self.info.sequences_are_aligned():
-            assert len(x.shape) == 2
+            # If the user passed an array of shape [b,],
+            # then we need to make sure that the sequences
+            # are aligned. Otherwise, we will raise an error.
+            if len(x.shape) == 1:
+                assert len(set([len(s) for s in x])) == 1, (
+                    "The sequences are not aligned. "
+                    "If you want to allow for variable-length inputs, set "
+                    "the maximum length of the problem to be L=np.inf or L=None. "
+                    "(and the aligned flag to False)."
+                )
+            else:
+                assert len(x.shape) == 2, (
+                    "Since the problem is aligned, we expected an array of shape (batch_size, L)."
+                    f" Instead, we got an array of shape {x.shape}."
+                )
+        else:
+            # At this point, we know that the sequences are not aligned.
+            # Which means that the user is likely to pass an array [b,]
+            # instead of an array [b, L]. We will reshape the input to
+            # be [b, 1] if it is not already.
+            if len(x.shape) == 1:
+                x = x.reshape(-1, 1)
+
         maximum_sequence_length = self.info.get_max_sequence_length()
 
         # We assert that the length matches L if the maximum sequence length
@@ -162,11 +191,20 @@ class AbstractBlackBox:
             maximum_sequence_length not in [np.inf, None]
             and self.info.sequences_are_aligned()
         ):
-            assert x.shape[1] == maximum_sequence_length, (
-                "The length of the input is not the same as the length of the input of the problem. "
-                f"(L={maximum_sequence_length}, x.shape[1]={x.shape[1]}). "
-                "If you want to allow for variable-length inputs, set L=np.inf or L=None."
-            )
+            if len(x.shape) == 1:
+                assert len(set([len(s) for s in x])) == 1, (
+                    "The sequences are not aligned. "
+                    "If you want to allow for variable-length inputs, set "
+                    "the maximum length of the problem to be L=np.inf or L=None. "
+                    "(and the aligned flag to False)."
+                )
+                x = x.reshape(-1, 1)
+            else:
+                assert x.shape[1] == maximum_sequence_length, (
+                    "The length of the input is not the same as the length of the input of the problem. "
+                    f"(L={maximum_sequence_length}, x.shape[1]={x.shape[1]}). "
+                    "If you want to allow for variable-length inputs, set L=np.inf or L=None."
+                )
 
         # Evaluate f by batches. If batch_size is None, then we evaluate
         # the whole input at once.
@@ -176,7 +214,8 @@ class AbstractBlackBox:
             batch_size = self.batch_size
         f_evals = []
 
-        # Check whether we have enough budget to evaluate the black box function.
+        # Check whether we have enough budget to evaluate the black box function
+        # in the current batch.
         if self._num_evaluations + batch_size > self.evaluation_budget:
             raise BudgetExhaustedException(
                 f"Exhausted the evaluation budget of {self.evaluation_budget} evaluations."

--- a/src/poli/core/util/alignment/__init__.py
+++ b/src/poli/core/util/alignment/__init__.py
@@ -1,0 +1,1 @@
+from .is_aligned import is_aligned_input

--- a/src/poli/core/util/alignment/is_aligned.py
+++ b/src/poli/core/util/alignment/is_aligned.py
@@ -1,4 +1,41 @@
-"""Utility function to check if the input to an "aligned"
+"""Utility model to check if the input to an "aligned"
 problem is indeed aligned.
-
 """
+import numpy as np
+
+
+def is_aligned_input(x: np.ndarray, maximum_sequence_length: int = None) -> bool:
+    """Utility function to check if the input to an "aligned"
+    problem is indeed aligned.
+
+    Our definition of alignment goes as follows:
+    - The input is of shape [b, L], where L is a defined maximum
+      length.
+    - If the input is of shape [b,], then the lengths of all
+      elements inside the batch are the same.
+    """
+    if maximum_sequence_length == np.inf:
+        maximum_sequence_length = None
+
+    # If the array is 2-dimensional, we only need to check
+    # if the second dimension is equal to the maximum sequence length
+    # (when provided)
+    if x.ndim == 2:
+        if maximum_sequence_length is not None:
+            return x.shape[1] == maximum_sequence_length
+        else:
+            return True
+    # If the array is 1-dimensional, we need to check if all
+    # elements have the same length
+    elif x.ndim == 1:
+        unique_lengths = set(map(len, x))
+        if len(unique_lengths) == 1:
+            if maximum_sequence_length is not None:
+                return unique_lengths.pop() == maximum_sequence_length
+            else:
+                return True
+        else:
+            # Then there's more than one length
+            return False
+    else:
+        return False

--- a/src/poli/core/util/alignment/is_aligned.py
+++ b/src/poli/core/util/alignment/is_aligned.py
@@ -1,0 +1,4 @@
+"""Utility function to check if the input to an "aligned"
+problem is indeed aligned.
+
+"""

--- a/src/poli/objective_repository/aloha/register.py
+++ b/src/poli/objective_repository/aloha/register.py
@@ -114,6 +114,12 @@ class AlohaBlackBox(AbstractBlackBox):
             inverse_alphabet = {v: k for k, v in self.alphabet.items()}
             x = np.array([[inverse_alphabet[i] for i in x[0]]])
 
+        if x.shape[1] == 1:
+            assert (
+                len(set([len(x_i) for x_i in x])) == 1
+            ), "All strings must have the same length."
+            x = np.array([list(x_i[0]) for x_i in x])
+
         matches = x == np.array(["A", "L", "O", "H", "A"])
         values = np.sum(matches.reshape(x.shape[0], 5), axis=1, keepdims=True).reshape(
             x.shape[0], 1

--- a/src/poli/objective_repository/rdkit_qed/register.py
+++ b/src/poli/objective_repository/rdkit_qed/register.py
@@ -202,7 +202,7 @@ class QEDProblemFactory(AbstractProblemFactory):
         return ProblemSetupInformation(
             name="rdkit_qed",
             max_sequence_length=np.inf,
-            aligned=True,
+            aligned=False,
             alphabet=None,
         )
 

--- a/src/poli/tests/registry/test_passing_array_of_strings.py
+++ b/src/poli/tests/registry/test_passing_array_of_strings.py
@@ -34,18 +34,21 @@ from poli.objective_repository import AVAILABLE_OBJECTIVES
                 "target_name": "ABL1",
             },
         ],
-        [
-            "drd3_docking",
-            [
-                ["C", ""],
-                ["C", "C"],
-            ],
-            [
-                "C",
-                "CC",
-            ],
-            {},
-        ],
+        # We remove drd3 docking from this check, because
+        # it doesn't register out-of-the-box. It needs the user
+        # to download a couple of files before using it.
+        # [
+        #     "drd3_docking",
+        #     [
+        #         ["C", ""],
+        #         ["C", "C"],
+        #     ],
+        #     [
+        #         "C",
+        #         "CC",
+        #     ],
+        #     {},
+        # ],
         # TODO: add foldx-related black boxes
         [
             "penalized_logp_lambo",

--- a/src/poli/tests/registry/test_passing_array_of_strings.py
+++ b/src/poli/tests/registry/test_passing_array_of_strings.py
@@ -50,18 +50,20 @@ from poli.objective_repository import AVAILABLE_OBJECTIVES
         #     {},
         # ],
         # TODO: add foldx-related black boxes
-        [
-            "penalized_logp_lambo",
-            [
-                ["C", ""],
-                ["C", "C"],
-            ],
-            [
-                "C",
-                "CC",
-            ],
-            {},
-        ],
+        # TODO: Once we can add lambo automatically, we can
+        # uncomment this test:
+        # [
+        #     "penalized_logp_lambo",
+        #     [
+        #         ["C", ""],
+        #         ["C", "C"],
+        #     ],
+        #     [
+        #         "C",
+        #         "CC",
+        #     ],
+        #     {},
+        # ],
         # TODO: add rasp
         [
             "rdkit_logp",

--- a/src/poli/tests/registry/test_passing_array_of_strings.py
+++ b/src/poli/tests/registry/test_passing_array_of_strings.py
@@ -1,0 +1,121 @@
+"""This module tests whether giving black boxes an array of b strings
+is equivalent to giving them an array of [b, L] tokens."""
+from typing import List
+
+import pytest
+
+from poli.objective_repository import AVAILABLE_OBJECTIVES
+
+
+# TODO: parametrize by all non-aligned blackboxes
+@pytest.mark.parametrize(
+    "black_box_name, example_non_flat_input, example_flat_input, kwargs",
+    [
+        [
+            "aloha",
+            [["A", "L", "O", "O", "F"], ["A", "L", "O", "H", "A"]],
+            [
+                "ALOOF",
+                "ALOHA",
+            ],
+            {},
+        ],
+        [
+            "dockstring",
+            [
+                ["C", ""],
+                ["C", "C"],
+            ],
+            [
+                "C",
+                "CC",
+            ],
+            {
+                "target_name": "ABL1",
+            },
+        ],
+        [
+            "drd3_docking",
+            [
+                ["C", ""],
+                ["C", "C"],
+            ],
+            [
+                "C",
+                "CC",
+            ],
+            {},
+        ],
+        # TODO: add foldx-related black boxes
+        [
+            "penalized_logp_lambo",
+            [
+                ["C", ""],
+                ["C", "C"],
+            ],
+            [
+                "C",
+                "CC",
+            ],
+            {},
+        ],
+        # TODO: add rasp
+        [
+            "rdkit_logp",
+            [
+                ["C", ""],
+                ["C", "C"],
+            ],
+            [
+                "C",
+                "CC",
+            ],
+            {},
+        ],
+        [
+            "rdkit_qed",
+            [
+                ["C", ""],
+                ["C", "C"],
+            ],
+            [
+                "C",
+                "CC",
+            ],
+            {},
+        ],
+        [
+            "sa_tdc",
+            [
+                ["C", ""],
+                ["C", "C"],
+            ],
+            [
+                "C",
+                "CC",
+            ],
+            {},
+        ],
+    ],
+)
+def test_passing_array_of_strings(
+    black_box_name: str,
+    example_non_flat_input: List[List[str]],
+    example_flat_input: List[str],
+    kwargs: dict,
+):
+    """This test checks whether passing an array of strings [b,]
+    to a black box is equivalent to passing an array of [b, L] tokens.
+    """
+    import numpy as np
+    from poli import create
+
+    _, f, _, _, _ = create(
+        name=black_box_name,
+        **kwargs,
+    )
+
+    x_flat = np.array(example_flat_input)
+    x_non_flat = np.array(example_non_flat_input)
+
+    assert (f(x_flat) == f(x_non_flat)).all()

--- a/src/poli/tests/registry/test_passing_array_of_strings.py
+++ b/src/poli/tests/registry/test_passing_array_of_strings.py
@@ -118,4 +118,21 @@ def test_passing_array_of_strings(
     x_flat = np.array(example_flat_input)
     x_non_flat = np.array(example_non_flat_input)
 
-    assert (f(x_flat) == f(x_non_flat)).all()
+    assert np.array_equal(f(x_flat), f(x_non_flat), equal_nan=True)
+
+
+if __name__ == "__main__":
+    test_passing_array_of_strings(
+        "dockstring",
+        [
+            ["C", ""],
+            ["C", "C"],
+        ],
+        [
+            "C",
+            "CC",
+        ],
+        {
+            "target_name": "ABL1",
+        },
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ basepython = python3.9
 wheel_build_env = .pkg
 deps=
     {[testenv]deps}
-    numpy
+    -r requirements.txt
     -e.
 commands=
     {[testenv]commands}


### PR DESCRIPTION
(Closes #121 )

Before this PR, all problems with `aligned=True` would throw an exception when evaluated on arrays of shape `[b,]`, even if the sequences inside the array indeed had the same length.

This PR allows users to evaluate e.g. `f(np.array(["C", "CC"]))` instead of `f(np.array([["C", ""], ["C", "C"]]))`. Making black-box evaluation much more user-friendly.