### PR TITLE
132 problem factories fixed size initial dataset rfp and gfp

### DIFF
--- a/src/poli/objective_repository/foldx_stability_and_sasa/register.py
+++ b/src/poli/objective_repository/foldx_stability_and_sasa/register.py
@@ -280,6 +280,9 @@ class FoldXStabilityAndSASAProblemFactory(AbstractProblemFactory):
         if alphabet is None:
             alphabet = self.get_setup_information().get_alphabet()
 
+        if n_starting_points is None:
+            n_starting_points = len(wildtype_pdb_path)
+
         # For a comparable RFP definition we require the sequences of the Pareto front:
         pareto_sequences_name_pdb_dict = {
             "DsRed.M1": "2VAD",

--- a/src/poli/objective_repository/gfp_cbas/register.py
+++ b/src/poli/objective_repository/gfp_cbas/register.py
@@ -157,7 +157,7 @@ class GFPCBasProblemFactory(AbstractProblemFactory):
         parallelize: bool = False,
         num_workers: int = None,
         evaluation_budget: int = 100000,
-        x0_size: int = 128,  # TODO: this should go into problem info instead?
+        n_starting_points: int = 128,
     ) -> Tuple[AbstractBlackBox, np.ndarray, np.ndarray]:
         """
         Seed value required to shuffle the data, otherwise CSV asset data index unchanged.
@@ -172,7 +172,7 @@ class GFPCBasProblemFactory(AbstractProblemFactory):
             num_workers=num_workers,
             seed=seed,
         )
-        x0 = np.array([list(s) for s in f.data_df.iloc[:x0_size].aaSequence])
+        x0 = np.array([list(s) for s in f.data_df.iloc[:n_starting_points].aaSequence])
         f_0 = f(x0)
 
         return f, x0, f_0

--- a/src/poli/objective_repository/gfp_cbas/register.py
+++ b/src/poli/objective_repository/gfp_cbas/register.py
@@ -162,6 +162,11 @@ class GFPCBasProblemFactory(AbstractProblemFactory):
         """
         Seed value required to shuffle the data, otherwise CSV asset data index unchanged.
         """
+        if problem_type.lower() not in ["gp", "vae", "elbo"]:
+            raise NotImplementedError(
+                f"Specified problem type: {problem_type} does not exist!"
+            )
+        self.problem_type = problem_type  # required in class scope for setup info
         seed_numpy(seed)
         seed_python(seed)
         problem_info = self.get_setup_information()


### PR DESCRIPTION
found a bug for the default case and fixed it. 

If `n_starting_points` is `None` the factory create fails.

If the parameter is not provided we take the number of provided files (list of Paths).