### PR TITLE
Bugfix: parallelization flag in `foldx` now changes batch size accordingly.

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -27,8 +27,8 @@ The bleeding-edge is contained in the `dev` branch, so if you want to install th
 To make sure everything went well, you can test your `poli` installation by running
 
 ```bash
-$ python -c "from poli.core.registry import get_problems ; print(get_problems())"
-['aloha', 'white_noise']
+$ python -c "from poli.core.registry import get_problems ; print(get_problems(only_available=True))"
+['aloha', ..., 'white_noise']
 ```
 
 If the installation isn't fresh/isn't the only one in your system, you might actually get some more names inside that list.
@@ -54,19 +54,19 @@ If you have enough dependencies to run an objective function, it will become ava
 
 ```bash
 $ pip install rdkit selfies
-$ python -c "from poli.core.registry import get_problems ; print(get_problems())"
-['aloha', 'rdkit_logp', 'rdkit_qed', 'white_noise']
+$ python -c "from poli.core.registry import get_problems ; print(get_problems(only_available=True))"
+['aloha', ..., 'rdkit_logp', 'rdkit_qed', ..., 'white_noise']
 ```
 
 Now that both `rdkit` and `selfies` are in the current environment, problems like computing `logp` and `qed` of SELFIES or SMILES strings become available.
 
 ### Calling objective functions in isolated enviroments
 
-To get a list of all avilable objective functions, you can pass the `include_repository=True` flag to `get_problems`:
+To get a list of all avilable objective functions, you can pass the `only_available=False` flag to `get_problems`:
 
 ```bash
-$ python -c "from poli.core.registry import get_problems ; print(get_problems(include_repository=True))"
-['aloha', 'drd3_docking', 'foldx_sasa', 'foldx_stability', ..., 'white_noise']
+$ python -c "from poli.core.registry import get_problems ; print(get_problems(only_available=False))"
+['aloha', 'dockstring', 'drd3_docking', 'foldx_sasa', 'foldx_stability', ..., 'white_noise']
 ```
 
 **Most of these objective functions can be run out-of-the-box** in isolated enviroments. For example, consider computing the synthetic accessibility of a molecule using `pytdc`. This problem is called `sa_tdc` in `poli`, and can easily be run without having the right dependencies installed:

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: poli
+name: poli-base
 channels:
   - defaults
 dependencies:
@@ -9,4 +9,3 @@ dependencies:
     - rdkit
     - biopython
     - selfies
-    - dockstring

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "numpy",
     "rdkit",
     "selfies",
-    "dockstring"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 numpy
 rdkit
 selfies
-dockstring

--- a/src/poli/core/proteins/foldx_black_box.py
+++ b/src/poli/core/proteins/foldx_black_box.py
@@ -132,9 +132,18 @@ class FoldxBlackBox(AbstractBlackBox):
         )
 
         # In the specific case of FoldX black boxes,
-        # the default batch size is 1.
+        # the default batch size is 1. However, if
+        # the user passed parallelize=True, then
+        # the batch size is set to the number of
+        # workers.
         if batch_size is None:
-            batch_size = 1
+            if parallelize:
+                if num_workers is None:
+                    num_workers = cpu_count() // 2
+                else:
+                    batch_size = num_workers
+            else:
+                batch_size = 1
 
         super().__init__(
             info=info,

--- a/src/poli/core/registry.py
+++ b/src/poli/core/registry.py
@@ -292,13 +292,13 @@ def delete_problem(problem_name: str):
     _write_config()
 
 
-def get_problems(include_repository: bool = True) -> List[str]:
+def get_problems(only_available: bool = False) -> List[str]:
     """Returns a list of registered problems.
 
     Parameters
     ----------
-    include_repository : bool
-        Whether to include the problems from the repository.
+    only_available : bool
+        Whether to only include the problems that can be imported directly.
 
     Returns
     -------
@@ -307,8 +307,8 @@ def get_problems(include_repository: bool = True) -> List[str]:
 
     Notes
     -----
-    If include_repository is True, the problems from the repository will be
-    included in the list. Otherwise, only the problems registered by the user
+    If only_available is False, the problems from the repository will be
+    included in the list. Otherwise, only the problems registered by the user/readily available
     will be included.
     """
     problems = config.sections()
@@ -320,7 +320,7 @@ def get_problems(include_repository: bool = True) -> List[str]:
     # objective_repository
     available_problems = list(AVAILABLE_PROBLEM_FACTORIES.keys())
 
-    if include_repository:
+    if not only_available:
         # We include the problems that the user _could_
         # install from the repo. These are available in the
         # AVAILABLE_OBJECTIVES list.


### PR DESCRIPTION
Before this PR, we needed to specify the appropriate `batch_size` when using `parallelize=True` in the `foldx` black boxes. Now it infers it from the number of workers if it wasn't specified.