### PR TITLE
Abstracts away isolated function imports

### DIFF
--- a/src/poli/core/chemistry/tdc_black_box.py
+++ b/src/poli/core/chemistry/tdc_black_box.py
@@ -22,10 +22,7 @@ import numpy as np
 
 from poli.core.abstract_black_box import AbstractBlackBox
 
-from poli.core.util.isolation.instancing import (
-    instance_function_as_isolated_process,
-    get_inner_function,
-)
+from poli.core.util.isolation.instancing import get_inner_function
 
 
 class TDCBlackBox(AbstractBlackBox):

--- a/src/poli/objective_repository/dockstring/register.py
+++ b/src/poli/objective_repository/dockstring/register.py
@@ -34,10 +34,7 @@ from poli.core.util.chemistry.string_to_molecule import (
 
 from poli.core.util.seeding import seed_python_numpy_and_torch
 
-from poli.core.util.isolation.instancing import (
-    instance_function_as_isolated_process,
-    get_inner_function,
-)
+from poli.core.util.isolation.instancing import get_inner_function
 
 from poli.objective_repository.dockstring.information import (
     dockstring_black_box_information,

--- a/src/poli/objective_repository/foldx_stability/register.py
+++ b/src/poli/objective_repository/foldx_stability/register.py
@@ -14,6 +14,8 @@ also use biopython for pre-processing the PDB files [2].
     bioinformatics. Bioinformatics, 25, 1422-1423
 """
 
+from __future__ import annotations
+
 from pathlib import Path
 from typing import List, Union
 
@@ -27,7 +29,7 @@ from poli.core.exceptions import FoldXNotFoundException
 
 from poli.core.util.seeding import seed_python_numpy_and_torch
 
-from poli.core.util.isolation.instancing import instance_function_as_isolated_process
+from poli.core.util.isolation.instancing import get_inner_function
 
 from poli.objective_repository.foldx_stability.information import foldx_stability_info
 
@@ -88,41 +90,29 @@ class FoldXStabilityBlackBox(AbstractBlackBox):
             num_workers=num_workers,
             evaluation_budget=evaluation_budget,
         )
+        self.wildtype_pdb_path = wildtype_pdb_path
+        self.experiment_id = experiment_id
+        self.tmp_folder = tmp_folder
+        self.eager_repair = eager_repair
+        self.verbose = verbose
+        self.force_isolation = force_isolation
+
         if not (Path.home() / "foldx" / "foldx").exists():
             raise FoldXNotFoundException(
                 "FoldX wasn't found in ~/foldx/foldx. Please install it."
             )
-        if not force_isolation:
-            try:
-                from poli.objective_repository.foldx_stability.isolated_function import (
-                    FoldXStabilityIsolatedLogic,
-                )
 
-                self.inner_function = FoldXStabilityIsolatedLogic(
-                    wildtype_pdb_path=wildtype_pdb_path,
-                    experiment_id=experiment_id,
-                    tmp_folder=tmp_folder,
-                    eager_repair=eager_repair,
-                    verbose=verbose,
-                )
-            except ImportError:
-                self.inner_function = instance_function_as_isolated_process(
-                    name="foldx_stability__isolated",
-                    wildtype_pdb_path=wildtype_pdb_path,
-                    experiment_id=experiment_id,
-                    tmp_folder=tmp_folder,
-                    eager_repair=eager_repair,
-                    verbose=verbose,
-                )
-        else:
-            self.inner_function = instance_function_as_isolated_process(
-                name="foldx_stability__isolated",
-                wildtype_pdb_path=wildtype_pdb_path,
-                experiment_id=experiment_id,
-                tmp_folder=tmp_folder,
-                eager_repair=eager_repair,
-                verbose=verbose,
-            )
+        self.inner_function = get_inner_function(
+            isolated_function_name="foldx_stability__isolated",
+            class_name="FoldXStabilityIsolatedLogic",
+            module_to_import="poli.objective_repository.foldx_stability.isolated_function",
+            force_isolation=force_isolation,
+            wildtype_pdb_path=wildtype_pdb_path,
+            experiment_id=experiment_id,
+            tmp_folder=tmp_folder,
+            eager_repair=eager_repair,
+            verbose=verbose,
+        )
 
     def _black_box(self, x: np.ndarray, context: None) -> np.ndarray:
         """
@@ -147,7 +137,19 @@ class FoldXStabilityBlackBox(AbstractBlackBox):
             The array of stability scores.
 
         """
-        return self.inner_function(x, context)
+        inner_function = get_inner_function(
+            isolated_function_name="foldx_stability__isolated",
+            class_name="FoldXStabilityIsolatedLogic",
+            module_to_import="poli.objective_repository.foldx_stability.isolated_function",
+            force_isolation=self.force_isolation,
+            quiet=True,
+            wildtype_pdb_path=self.wildtype_pdb_path,
+            experiment_id=self.experiment_id,
+            tmp_folder=self.tmp_folder,
+            eager_repair=self.eager_repair,
+            verbose=self.verbose,
+        )
+        return inner_function(x, context)
 
     @staticmethod
     def get_black_box_info() -> BlackBoxInformation:
@@ -262,6 +264,9 @@ class FoldXStabilityProblemFactory(AbstractProblemFactory):
             force_isolation=force_isolation,
         )
         wildtype_amino_acids_ = f.inner_function.wildtype_amino_acids
+
+        del f.inner_function
+
         longest_wildtype_length = max([len(x) for x in wildtype_amino_acids_])
 
         wildtype_amino_acids = [

--- a/src/poli/objective_repository/foldx_stability/register.py
+++ b/src/poli/objective_repository/foldx_stability/register.py
@@ -102,7 +102,7 @@ class FoldXStabilityBlackBox(AbstractBlackBox):
                 "FoldX wasn't found in ~/foldx/foldx. Please install it."
             )
 
-        self.inner_function = get_inner_function(
+        inner_function = get_inner_function(
             isolated_function_name="foldx_stability__isolated",
             class_name="FoldXStabilityIsolatedLogic",
             module_to_import="poli.objective_repository.foldx_stability.isolated_function",
@@ -113,6 +113,7 @@ class FoldXStabilityBlackBox(AbstractBlackBox):
             eager_repair=eager_repair,
             verbose=verbose,
         )
+        self.wildtype_amino_acids = inner_function.wildtype_amino_acids
 
     def _black_box(self, x: np.ndarray, context: None) -> np.ndarray:
         """
@@ -263,9 +264,7 @@ class FoldXStabilityProblemFactory(AbstractProblemFactory):
             evaluation_budget=evaluation_budget,
             force_isolation=force_isolation,
         )
-        wildtype_amino_acids_ = f.inner_function.wildtype_amino_acids
-
-        del f.inner_function
+        wildtype_amino_acids_ = f.wildtype_amino_acids
 
         longest_wildtype_length = max([len(x) for x in wildtype_amino_acids_])
 

--- a/src/poli/objective_repository/gfp_cbas/register.py
+++ b/src/poli/objective_repository/gfp_cbas/register.py
@@ -12,7 +12,10 @@ from poli.core.util.seeding import seed_python_numpy_and_torch
 
 from poli.objective_repository.gfp_cbas.information import gfp_cbas_info
 
-from poli.core.util.isolation.instancing import instance_function_as_isolated_process
+from poli.core.util.isolation.instancing import (
+    instance_function_as_isolated_process,
+    get_inner_function,
+)
 
 
 class GFPCBasBlackBox(AbstractBlackBox):
@@ -36,49 +39,49 @@ class GFPCBasBlackBox(AbstractBlackBox):
             num_workers=num_workers,
             evaluation_budget=evaluation_budget,
         )
-        if not force_isolation:
-            try:
-                from poli.objective_repository.gfp_cbas.isolated_function import (
-                    GFPCBasIsolatedLogic,
-                )
+        self.problem_type = problem_type
+        self.functional_only = functional_only
+        self.ignore_stops = ignore_stops
+        self.unique = unique
+        self.force_isolation = force_isolation
+        self.n_starting_points = n_starting_points
+        self.seed = seed
 
-                self.inner_function = GFPCBasIsolatedLogic(
-                    problem_type=problem_type,
-                    info=gfp_cbas_info,
-                    n_starting_points=n_starting_points,
-                    seed=seed,
-                    functional_only=functional_only,
-                    ignore_stops=ignore_stops,
-                    unique=unique,
-                )
-            except ImportError:
-                self.inner_function = instance_function_as_isolated_process(
-                    name="gfp_cbas__isolated",
-                    problem_type=problem_type,
-                    info=gfp_cbas_info,
-                    n_starting_points=n_starting_points,
-                    seed=seed,
-                    functional_only=functional_only,
-                    ignore_stops=ignore_stops,
-                    unique=unique,
-                )
-        else:
-            self.inner_function = instance_function_as_isolated_process(
-                name="gfp_cbas__isolated",
-                problem_type=problem_type,
-                info=gfp_cbas_info,
-                n_starting_points=n_starting_points,
-                seed=seed,
-                functional_only=functional_only,
-                ignore_stops=ignore_stops,
-                unique=unique,
-            )
+        inner_function = get_inner_function(
+            isolated_function_name="gfp_cbas__isolated",
+            class_name="GFPCBasIsolatedLogic",
+            module_to_import="poli.objective_repository.gfp_cbas.isolated_function",
+            seed=self.seed,
+            force_isolation=self.force_isolation,
+            quiet=False,
+            problem_type=self.problem_type,
+            info=gfp_cbas_info,
+            n_starting_points=self.n_starting_points,
+            functional_only=self.functional_only,
+            ignore_stops=self.ignore_stops,
+            unique=self.unique,
+        )
+        self.x0 = inner_function.x0
 
     def _black_box(self, x: np.array, context=None) -> np.ndarray:
         """
         x is encoded sequence return function value given problem name
         """
-        return self.inner_function(x, context=context)
+        inner_function = get_inner_function(
+            isolated_function_name="gfp_cbas__isolated",
+            class_name="GFPCBasIsolatedLogic",
+            module_to_import="poli.objective_repository.gfp_cbas.isolated_function",
+            seed=self.seed,
+            force_isolation=self.force_isolation,
+            quiet=True,
+            problem_type=self.problem_type,
+            info=gfp_cbas_info,
+            n_starting_points=self.n_starting_points,
+            functional_only=self.functional_only,
+            ignore_stops=self.ignore_stops,
+            unique=self.unique,
+        )
+        return inner_function(x, context=context)
 
     def __iter__(self, *args, **kwargs):
         warn(f"{self.__class__.__name__} iteration invoked. Not implemented!")
@@ -140,7 +143,7 @@ class GFPCBasProblemFactory(AbstractProblemFactory):
             seed=seed,
             evaluation_budget=evaluation_budget,
         )
-        x0 = f.inner_function.x0
+        x0 = f.x0
 
         problem = Problem(f, x0)
 

--- a/src/poli/objective_repository/gfp_cbas/register.py
+++ b/src/poli/objective_repository/gfp_cbas/register.py
@@ -12,10 +12,7 @@ from poli.core.util.seeding import seed_python_numpy_and_torch
 
 from poli.objective_repository.gfp_cbas.information import gfp_cbas_info
 
-from poli.core.util.isolation.instancing import (
-    instance_function_as_isolated_process,
-    get_inner_function,
-)
+from poli.core.util.isolation.instancing import get_inner_function
 
 
 class GFPCBasBlackBox(AbstractBlackBox):

--- a/src/poli/objective_repository/super_mario_bros/register.py
+++ b/src/poli/objective_repository/super_mario_bros/register.py
@@ -19,10 +19,7 @@ from poli.core.problem import Problem
 
 from poli.core.util.seeding import seed_python_numpy_and_torch
 
-from poli.core.util.isolation.instancing import (
-    instance_function_as_isolated_process,
-    get_inner_function,
-)
+from poli.core.util.isolation.instancing import get_inner_function
 
 from poli.objective_repository.super_mario_bros.information import smb_info
 

--- a/src/poli/objective_repository/super_mario_bros/register.py
+++ b/src/poli/objective_repository/super_mario_bros/register.py
@@ -19,7 +19,10 @@ from poli.core.problem import Problem
 
 from poli.core.util.seeding import seed_python_numpy_and_torch
 
-from poli.core.util.isolation.instancing import instance_function_as_isolated_process
+from poli.core.util.isolation.instancing import (
+    instance_function_as_isolated_process,
+    get_inner_function,
+)
 
 from poli.objective_repository.super_mario_bros.information import smb_info
 
@@ -90,33 +93,32 @@ class SuperMarioBrosBlackBox(AbstractBlackBox):
             num_workers=num_workers,
             evaluation_budget=evaluation_budget,
         )
-        if not force_isolation:
-            try:
-                from poli.objective_repository.super_mario_bros.isolated_function import (
-                    SMBIsolatedLogic,
-                )
-
-                self.inner_function = SMBIsolatedLogic(
-                    alphabet=smb_info.alphabet, max_time=max_time, visualize=visualize
-                )
-            except ImportError:
-                self.inner_function = instance_function_as_isolated_process(
-                    name="super_mario_bros__isolated",
-                    alphabet=smb_info.alphabet,
-                    max_time=max_time,
-                    visualize=visualize,
-                )
-        else:
-            self.inner_function = instance_function_as_isolated_process(
-                name="super_mario_bros__isolated",
-                alphabet=smb_info.alphabet,
-                max_time=max_time,
-                visualize=visualize,
-            )
+        self.force_isolation = force_isolation
+        self.max_time = max_time
+        self.visualize = visualize
+        _ = get_inner_function(
+            isolated_function_name="super_mario_bros__isolated",
+            class_name="SMBIsolatedLogic",
+            module_to_import="poli.objective_repository.super_mario_bros.isolated_function",
+            force_isolation=self.force_isolation,
+            alphabet=smb_info.alphabet,
+            max_time=self.max_time,
+            visualize=self.visualize,
+        )
 
     def _black_box(self, x: np.ndarray, context=None) -> np.ndarray:
         """Computes number of jumps in a given latent code x."""
-        return self.inner_function(x, context)
+        inner_function = get_inner_function(
+            isolated_function_name="super_mario_bros__isolated",
+            class_name="SMBIsolatedLogic",
+            module_to_import="poli.objective_repository.super_mario_bros.isolated_function",
+            force_isolation=self.force_isolation,
+            quiet=True,
+            alphabet=smb_info.alphabet,
+            max_time=self.max_time,
+            visualize=self.visualize,
+        )
+        return inner_function(x, context)
 
     @staticmethod
     def get_black_box_info() -> BlackBoxInformation:

--- a/src/poli/tests/parallelization/test_parallelization.py
+++ b/src/poli/tests/parallelization/test_parallelization.py
@@ -71,6 +71,9 @@ def test_parallelization_in_foldx_stability_and_sasa():
         force_register=True,
     )
 
+    f, x0 = problem.black_box, problem.x0
+    f(x0)
+
 
 if __name__ == "__main__":
     test_parallelization_in_foldx_stability_and_sasa()


### PR DESCRIPTION
This PR fixes a bug we had on parallel running of `foldx` (see the discussion in #184).

In the process, I've also implemented a `get_inner_function` utility that abstracts away the ugly code repetition we had on every isolate-able black box.

(Closes #184 and closes #172)