### PR TITLE
Bugfix: determines alignment dynamically in RaSP

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "poli"
-version = "1.0.0.dev6"
+version = "1.0.0.dev7"
 description = "poli, a library of discrete objective functions"
 readme = "README.md"
 authors = [{name="Miguel González-Duque", email="miguelgondu@gmail.com"}, {name="Simon Bartels"}]
@@ -53,7 +53,7 @@ profile = "black"
 exclude = ["src/poli/core/util/proteins/rasp/inner_rasp", "src/poli/objective_repository/gfp_cbas"]
 
 [tool.bumpversion]
-current_version = "1.0.0.dev6"
+current_version = "1.0.0.dev7"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = poli
-version = "1.0.0.dev6"
+version = "1.0.0.dev7"
 author_email = miguel.gonzalez-duque@bio.ku.dk
 description = Protein Objectives Library
 long_description = file: README.md

--- a/src/poli/__init__.py
+++ b/src/poli/__init__.py
@@ -1,6 +1,6 @@
 """poli, a library for discrete black-box objective functions."""
 
-__version__ = "1.0.0.dev6"
+__version__ = "1.0.0.dev7"
 from .core.util.isolation.instancing import instance_function_as_isolated_process
 
 # from .core import get_problems

--- a/src/poli/objective_repository/rasp/isolated_function.py
+++ b/src/poli/objective_repository/rasp/isolated_function.py
@@ -326,7 +326,7 @@ class RaspIsolatedLogic(AbstractIsolatedFunction):
                 # We return the penalization value with a minus sign
                 # since we are maximizing the stability (i.e. there
                 # is a sign flip at the end of the __call__ method).
-                return np.array([-self.penalize_unfeasible_with]).reshape(1, 1)
+                return np.array([-self.penalize_unfeasible_with])
             else:
                 raise ValueError(
                     "The mutant's length does not match any of the wildtypes. If "

--- a/src/poli/objective_repository/rasp/register.py
+++ b/src/poli/objective_repository/rasp/register.py
@@ -212,7 +212,7 @@ class RaspBlackBox(AbstractBlackBox):
         return BlackBoxInformation(
             name="rasp",
             max_sequence_length=max([len("".join(x)) for x in self.x0]),
-            aligned=True,
+            aligned=False,
             fixed_length=False,
             deterministic=True,
             alphabet=AMINO_ACIDS,

--- a/src/poli/objective_repository/rasp/register.py
+++ b/src/poli/objective_repository/rasp/register.py
@@ -209,11 +209,14 @@ class RaspBlackBox(AbstractBlackBox):
         """
         Returns the black box information for RaSP.
         """
+        is_aligned = False if len(self.wildtype_pdb_path) > 1 else True
+        is_fixed_length = False if len(self.wildtype_pdb_path) > 1 else True
+        max_sequence_length = max([len("".join(x)) for x in self.x0])
         return BlackBoxInformation(
             name="rasp",
-            max_sequence_length=max([len("".join(x)) for x in self.x0]),
-            aligned=False,
-            fixed_length=False,
+            max_sequence_length=max_sequence_length,
+            aligned=is_aligned,
+            fixed_length=is_fixed_length,
             deterministic=True,
             alphabet=AMINO_ACIDS,
             log_transform_recommended=False,

--- a/src/poli/tests/registry/proteins/test_rasp.py
+++ b/src/poli/tests/registry/proteins/test_rasp.py
@@ -160,3 +160,22 @@ def test_rasp_penalization_works():
     # that is _not_ the same length as the wildtype.
     problematic_x = np.array([["A"] + [""] * (f.info.max_sequence_length - 1)])
     assert f(problematic_x) == -100.0
+
+
+@pytest.mark.poli__rasp
+def test_rasp_penalization_works_on_multiple_inputs():
+    problem = objective_factory.create(
+        name="rasp",
+        wildtype_pdb_path=THIS_DIR / "3ned.pdb",
+        additive=True,
+        penalize_unfeasible_with=-100.0,
+    )
+    f, _ = problem.black_box, problem.x0
+
+    # This is an unfeasible mutation, since joining
+    # all the strings would result in a sequence
+    # that is _not_ the same length as the wildtype.
+    problematic_x = np.array([["A"] + [""] * (f.info.max_sequence_length - 1)])
+    combination = np.vstack([problem.x0, problematic_x])
+    y = f(combination)
+    assert y[-1] == -100.0


### PR DESCRIPTION
In some scenarios (e.g. when having more than one wildtype), `aligned` should be False in RaSP.