### PR TITLE
Updates `RaSP` to throw an error on invalid inputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "poli"
-version = "1.0.0.dev8"
+version = "1.0.0.dev9"
 description = "poli, a library of discrete objective functions"
 readme = "README.md"
 authors = [{name="Miguel González-Duque", email="miguelgondu@gmail.com"}, {name="Simon Bartels"}]
@@ -53,7 +53,7 @@ profile = "black"
 exclude = ["src/poli/core/util/proteins/rasp/inner_rasp", "src/poli/objective_repository/gfp_cbas"]
 
 [tool.bumpversion]
-current_version = "1.0.0.dev8"
+current_version = "1.0.0.dev9"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = poli
-version = "1.0.0.dev8"
+version = "1.0.0.dev9"
 author_email = miguel.gonzalez-duque@bio.ku.dk
 description = Protein Objectives Library
 long_description = file: README.md

--- a/src/poli/__init__.py
+++ b/src/poli/__init__.py
@@ -1,6 +1,6 @@
 """poli, a library for discrete black-box objective functions."""
 
-__version__ = "1.0.0.dev8"
+__version__ = "1.0.0.dev9"
 from .core.util.isolation.instancing import instance_function_as_isolated_process
 
 # from .core import get_problems

--- a/src/poli/core/util/proteins/rasp/rasp_interface.py
+++ b/src/poli/core/util/proteins/rasp/rasp_interface.py
@@ -108,6 +108,28 @@ class RaspInterface:
         self.download_cavity_and_downstream_models(
             verbose=verbose, verify_integrity_of_download=verify_integrity_of_download
         )
+        self.alphabet = [
+            "A",
+            "C",
+            "D",
+            "E",
+            "F",
+            "G",
+            "H",
+            "I",
+            "K",
+            "L",
+            "M",
+            "N",
+            "P",
+            "Q",
+            "R",
+            "S",
+            "T",
+            "V",
+            "W",
+            "Y",
+        ]
 
     def get_and_compile_reduce(self):
         """
@@ -513,28 +535,7 @@ class RaspInterface:
         df_structure_no_mt["pdbid"] = res_info["pdb_id"]
         df_structure_no_mt["chainid"] = res_info["chain_id"]
         df_structure_no_mt["variant"] = res_info["wt_AA"] + res_info["pos"] + "X"
-        aa_list = [
-            "A",
-            "C",
-            "D",
-            "E",
-            "F",
-            "G",
-            "H",
-            "I",
-            "K",
-            "L",
-            "M",
-            "N",
-            "P",
-            "Q",
-            "R",
-            "S",
-            "T",
-            "V",
-            "W",
-            "Y",
-        ]
+        aa_list = self.alphabet
 
         # Considering ALL single mutations in ALL sites.
         wildtype_residue_string = "".join(

--- a/src/poli/objective_repository/rasp/isolated_function.py
+++ b/src/poli/objective_repository/rasp/isolated_function.py
@@ -313,6 +313,12 @@ class RaspIsolatedLogic(AbstractIsolatedFunction):
     def _compute_mutant_residue_string_ddg(
         self, mutant_residue_string: str
     ) -> np.ndarray:
+        for i, char in enumerate(mutant_residue_string):
+            assert char in self.rasp_interface.alphabet, (
+                f"Invalid residue {char} at position {i} in the mutant residue string. "
+                f"Please make sure that all residues are in the alphabet: "
+                f"{self.rasp_interface.alphabet}."
+            )
         try:
             (
                 closest_wildtype_pdb_file,

--- a/src/poli/objective_repository/rasp/isolated_function.py
+++ b/src/poli/objective_repository/rasp/isolated_function.py
@@ -314,11 +314,12 @@ class RaspIsolatedLogic(AbstractIsolatedFunction):
         self, mutant_residue_string: str
     ) -> np.ndarray:
         for i, char in enumerate(mutant_residue_string):
-            assert char in self.rasp_interface.alphabet, (
-                f"Invalid residue {char} at position {i} in the mutant residue string. "
-                f"Please make sure that all residues are in the alphabet: "
-                f"{self.rasp_interface.alphabet}."
-            )
+            if char not in self.rasp_interface.alphabet:
+                raise ValueError(
+                    f"Invalid residue {char} at position {i} in the mutant "
+                    "residue string. Please make sure that all residues are "
+                    f"in the alphabet: {self.rasp_interface.alphabet}."
+                )
         try:
             (
                 closest_wildtype_pdb_file,

--- a/src/poli/tests/registry/proteins/test_rasp.py
+++ b/src/poli/tests/registry/proteins/test_rasp.py
@@ -179,3 +179,20 @@ def test_rasp_penalization_works_on_multiple_inputs():
     combination = np.vstack([problem.x0, problematic_x])
     y = f(combination)
     assert y[-1] == -100.0
+
+
+@pytest.mark.poli__rasp
+def test_rasp_fails_on_invalid_amino_acids():
+    problem = objective_factory.create(
+        name="rasp",
+        wildtype_pdb_path=THIS_DIR / "3ned.pdb",
+    )
+    f, x0 = problem.black_box, problem.x0
+
+    # This is an unfeasible mutation, since joining
+    # all the strings would result in a sequence
+    # that is _not_ the same length as the wildtype.
+    problematic_x = x0.copy()
+    problematic_x[0][0] = "B"
+    with pytest.raises(ValueError):
+        f(problematic_x)


### PR DESCRIPTION
`RaSP` is only able to compute mutations in the usual list of amino acids. Sampling from ESM-2, however, might land on amino acids like `B` or `J`. Now `RaSP` throws an error in those.