### PR TITLE
Adds support for uv installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ docs/source/generated/
 
 # Ignore slurm scripts
 slurm_scripts/
+
+# Ignore uv-related files
+uv.lock
+.python-version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ rmf = [
 ]
 rosetta_energy = [
     "biopython",
-    "pyrosetta",
+    "pyrosetta-installer",
 ]
 dev = ["black", "tox", "pytest", "bump-my-version"]
 docs = ["sphinx", "furo"]
@@ -144,3 +144,8 @@ replace = 'version = "{new_version}"'
 filename = "CITATION.cff"
 search = 'version: {current_version}'
 replace = 'version: {new_version}'
+
+[dependency-groups]
+dev = [
+    "pre-commit>=4.2.0",
+]


### PR DESCRIPTION
While adding support for `uv` installation, I just noticed that `pyrosetta` was improperly specified in the `pyproject.toml`. It's only available via `conda`, but one can install it using `pyrosetta-installer`. We should fix that next.