### PR TITLE
Adds more helpful error messages, always runs file registration for isolation

### DIFF
--- a/examples/minimal_isolation_example.py
+++ b/examples/minimal_isolation_example.py
@@ -1,0 +1,14 @@
+import numpy as np
+
+from poli.repository import EhrlichHoloBlackBox
+
+f = EhrlichHoloBlackBox(
+    sequence_length=10,
+    motif_length=3,
+    n_motifs=2,
+)
+
+print(f.alphabet)
+print(f)
+print(f(np.array(["ACGTACGTAA", "ACGTACGTAC"])))
+print(f)

--- a/src/poli/core/util/isolation/instancing.py
+++ b/src/poli/core/util/isolation/instancing.py
@@ -72,7 +72,11 @@ def __create_conda_env(environment_file: Path, quiet: bool = False):
             if not quiet:
                 print(f"poli 🧪: {env_name} already exists.")
         else:
-            raise e
+            raise RuntimeError(
+                "Failed to create the underlying conda environment."
+                " Try to create the environment manually by running:\n"
+                f"conda env create -f {environment_file}\n"
+            ) from e
 
 
 def __register_isolated_function_from_repository(

--- a/src/poli/core/util/isolation/instancing.py
+++ b/src/poli/core/util/isolation/instancing.py
@@ -216,31 +216,15 @@ def register_isolated_function(name: str, quiet: bool = False):
         If True, we squelch the messages giving feedback about the creation process.
         By default, it is False.
     """
-    config = load_config()
-    if name not in config:
-        # Register problem
-
-        # Two cases:
-        # (i) some of the isolated functions are not alongside
-        # their black boxes and problem factories, but are rather inside
-        # the core of poli. For now, the only case is tdc, but more may
-        # come in the future.
-        #
-        # (ii) the isolated function is in the repository, living alongside
-        # the black box and the problem factory.
-        if name == "tdc__isolated":
-            logging.debug(
-                "poli 🧪: Registered the isolated function from the repository."
-            )
-            __register_isolated_function_from_core(name, quiet=quiet)
-            config = load_config()
-        else:
-            logging.debug(
-                "poli 🧪: Registered the isolated function from the repository."
-            )
-            __register_isolated_function_from_repository(name, quiet=quiet)
-            # Refresh the config
-            config = load_config()
+    if name == "tdc__isolated":
+        logging.debug("poli 🧪: Registered the isolated function from core.")
+        __register_isolated_function_from_core(name, quiet=quiet)
+        _ = load_config()
+    else:
+        logging.debug("poli 🧪: Registered the isolated function from the repository.")
+        __register_isolated_function_from_repository(name, quiet=quiet)
+        # Refresh the config
+        _ = load_config()
 
 
 def __create_function_as_isolated_process(
@@ -266,6 +250,8 @@ def __create_function_as_isolated_process(
     **kwargs_for_factory : dict, optional
         Additional keyword arguments for the factory.
     """
+    register_isolated_function(name=name, quiet=quiet)
+
     config = load_config()
     if name not in config:
         raise ValueError(
@@ -322,9 +308,6 @@ def instance_function_as_isolated_process(
             "Check the documentation of the black box you are interested in for more information.\n"
             "https://machinelearninglifescience.github.io/poli-docs/."
         )
-
-    # Register the problem if it hasn't been registered.
-    register_isolated_function(name=name, quiet=quiet)
 
     f = __create_function_as_isolated_process(
         name=name,


### PR DESCRIPTION
With this change, we'll hopefully not need to run `rm -rf ~/.poli_objectives` too much. Now the config file is updated _every time_ a black box is run in isolation.